### PR TITLE
Adding Substream reproduction sample

### DIFF
--- a/Akka.Streams.Kafka.Reproduction.sln
+++ b/Akka.Streams.Kafka.Reproduction.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Streams.Kafka.Reproduc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Streams.Kafka.Reproduction.Producer", "src\Akka.Streams.Kafka.Reproduction.Producer\Akka.Streams.Kafka.Reproduction.Producer.csproj", "{320768E6-A458-4894-B162-0F725CB28590}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Streams.Kafka.Reproduction.SubstreamConsumer", "src\Akka.Streams.Kafka.Reproduction.SubstreamConsumer\Akka.Streams.Kafka.Reproduction.SubstreamConsumer.csproj", "{67D65D32-F038-4EFA-91EF-04A44BCEC763}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,5 +46,17 @@ Global
 		{320768E6-A458-4894-B162-0F725CB28590}.Release|x64.Build.0 = Release|Any CPU
 		{320768E6-A458-4894-B162-0F725CB28590}.Release|x86.ActiveCfg = Release|Any CPU
 		{320768E6-A458-4894-B162-0F725CB28590}.Release|x86.Build.0 = Release|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Debug|x64.Build.0 = Debug|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Debug|x86.Build.0 = Debug|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Release|x64.ActiveCfg = Release|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Release|x64.Build.0 = Release|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Release|x86.ActiveCfg = Release|Any CPU
+		{67D65D32-F038-4EFA-91EF-04A44BCEC763}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - zookeeper
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_NUM_PARTITIONS: 3
+      KAFKA_NUM_PARTITIONS: 10
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"

--- a/src/Akka.Streams.Kafka.Reproduction.Consumer/Akka.Streams.Kafka.Reproduction.Consumer.csproj
+++ b/src/Akka.Streams.Kafka.Reproduction.Consumer/Akka.Streams.Kafka.Reproduction.Consumer.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <RootNamespace>Akka.Streams.Kafka.Reproduction</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Akka.Streams.Kafka.Reproduction.SubstreamConsumer/Akka.Streams.Kafka.Reproduction.SubstreamConsumer.csproj
+++ b/src/Akka.Streams.Kafka.Reproduction.SubstreamConsumer/Akka.Streams.Kafka.Reproduction.SubstreamConsumer.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Aaron.Akka.Streams.BackpressureMonitor" Version="0.1.1" />
+        <PackageReference Include="Akka.Streams.Kafka" Version="$(AkkaStreamsKafkaVersion)" />
+    </ItemGroup>
+
+</Project>

--- a/src/Akka.Streams.Kafka.Reproduction.SubstreamConsumer/Program.cs
+++ b/src/Akka.Streams.Kafka.Reproduction.SubstreamConsumer/Program.cs
@@ -49,7 +49,7 @@ namespace Akka.Streams.Kafka.Reproduction.SubstreamConsumer
             var committerSettings = CommitterSettings.Create(actorSystem);
 
             var mappingFlow = (Flow<CommittableMessage<Null, string>, (string Topic, string Value, ICommittableOffset CommitableOffset), NotUsed>)Flow.Create<CommittableMessage<Null, string>>()
-                .GroupBy(3, message => message.Record.Partition.Value)
+                .GroupBy(10, message => message.Record.Partition.Value)
                 .Select(c => (c.Record.Topic, c.Record.Message.Value, c.CommitableOffset))
                 .SelectAsync(1, async t =>
                 {

--- a/src/Akka.Streams.Kafka.Reproduction.SubstreamConsumer/Program.cs
+++ b/src/Akka.Streams.Kafka.Reproduction.SubstreamConsumer/Program.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Aaron.Akka.Streams.Dsl;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Streams.Dsl;
+using Akka.Streams.Kafka.Dsl;
+using Akka.Streams.Kafka.Helpers;
+using Akka.Streams.Kafka.Messages;
+using Akka.Streams.Kafka.Settings;
+using Akka.Util.Internal;
+using Confluent.Kafka;
+
+namespace Akka.Streams.Kafka.Reproduction.SubstreamConsumer
+{
+    class Program
+    {
+         static async Task Main(string[] args)
+        {
+            var configSetup = BootstrapSetup.Create().WithConfig(KafkaExtensions.DefaultSettings);
+            var actorSystem = ActorSystem.Create("KafkaSpec", configSetup);
+            var materializer = actorSystem.Materializer();
+
+            var consumerConfig = new ConsumerConfig
+            {
+                EnableAutoCommit = true,
+                EnableAutoOffsetStore = false,
+                AllowAutoCreateTopics = true,
+                AutoOffsetReset = AutoOffsetReset.Latest,
+                ClientId = "unique.client",
+                SocketKeepaliveEnable = true,
+                ConnectionsMaxIdleMs = 180000
+            };
+
+            var consumerSettings = ConsumerSettings<Null, string>
+                .Create(actorSystem, null, null)
+                .WithBootstrapServers("localhost:29092")
+                .WithStopTimeout(TimeSpan.Zero)
+                .WithGroupId("group1");
+            
+            var producerSettings = ProducerSettings<Null, string>.Create(actorSystem,
+                    null, null)
+                .WithBootstrapServers("localhost:29092");
+            
+            // TODO: we should just be able to accept a `ConsumerConfig` property
+            consumerConfig.ForEach(kv => consumerSettings = consumerSettings.WithProperty(kv.Key, kv.Value));
+
+            var committerSettings = CommitterSettings.Create(actorSystem);
+
+            var mappingFlow = (Flow<CommittableMessage<Null, string>, (string Topic, string Value, ICommittableOffset CommitableOffset), NotUsed>)Flow.Create<CommittableMessage<Null, string>>()
+                .GroupBy(3, message => message.Record.Partition.Value)
+                .Select(c => (c.Record.Topic, c.Record.Message.Value, c.CommitableOffset))
+                .SelectAsync(1, async t =>
+                {
+                    // simulate a request-response call that takes 10ms to complete here
+                    await Task.Delay(10);
+                    return t;
+                })
+                .MergeSubstreams();
+
+            var drainingControl = KafkaConsumer.CommittableSource(consumerSettings, Subscriptions.Topics("akka-input"))
+                .BackpressureAlert(LogLevel.WarningLevel, TimeSpan.FromMilliseconds(500))
+                .WithAttributes(Attributes.CreateName("CommitableSource"))
+                .Via(mappingFlow)
+                .Select(t => ProducerMessage.Single(new ProducerRecord<Null, string>($"{t.Topic}-done", t.Value),
+                    t.CommitableOffset))
+                .BackpressureAlert(LogLevel.WarningLevel, TimeSpan.FromMilliseconds(500))
+                .Via(KafkaProducer.FlexiFlow<Null, string, ICommittableOffset>(producerSettings)).WithAttributes(Attributes.CreateName("FlexiFlow"))
+                .Select(m => (ICommittable)m.PassThrough)
+                .AlsoToMaterialized(Committer.Sink(committerSettings), DrainingControl<NotUsed>.Create)
+                .To(Flow.Create<ICommittable>()
+                    .Async()
+                    .GroupedWithin(1000, TimeSpan.FromSeconds(1))
+                    .Select(c => c.Count())
+                    .Log("MsgCount").AddAttributes(Attributes.CreateLogLevels(LogLevel.InfoLevel))
+                    .To(Sink.Ignore<int>()))
+                .Run(materializer);
+
+            Console.ReadLine();
+            await drainingControl.DrainAndShutdown();
+            await actorSystem.Terminate();
+        }
+    }
+}


### PR DESCRIPTION
Breaks the Kafka stream into 10 sub-partitions that are processed concurrently, merges them back together, and runs the `FlexiFlow` + `Commiter.Sink` afterwards